### PR TITLE
Remove clear durations url and view

### DIFF
--- a/timeTracker/urls.py
+++ b/timeTracker/urls.py
@@ -29,5 +29,4 @@ urlpatterns = [
     path('startTime/',      startTime,      name='startTime'),
     path('stopTime/',       stopTime,       name='stopTime'),
     path('durations/',      durations,      name='durations'),
-    path('clearDurations/', clearDurations, name='clearDurations'), #bad, will delete all your stuff!!!
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)  # static file servong during developement

--- a/timeTracking/views.py
+++ b/timeTracking/views.py
@@ -39,11 +39,6 @@ def stopTime(request):
             project.save()
             return JsonResponse({ "success":True })
     return JsonResponse({ "success":False })
-            
-def clearDurations(request):
-          timeSpent.objects.all().delete()
-          Project.objects.all().delete()
-          return JsonResponse({ "success":True })
         
 def registerProject(request):
     


### PR DESCRIPTION
Removed duration clearing functionality. Originally used to delete all the test data when debugging the models.